### PR TITLE
back btn in order status page goes to dashboard

### DIFF
--- a/app/assets/stylesheets/components/_page_title.scss
+++ b/app/assets/stylesheets/components/_page_title.scss
@@ -1,3 +1,7 @@
 h1 {
   border-bottom: 0.5px solid lightgray;
 }
+
+#status-title {
+  padding-left: 0;
+}

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,5 +1,5 @@
 <div class='container mt-2 pt-5'>
-  <h1 class='m-0 pb-2'>Your Order Status</h1>
+  <h1 id='status-title' class='m-0 pb-2'>Your Order Status</h1>
   <h2 class='order-date mb-5'><%= @order.order_date.strftime("%B %d %Y") %></h2>
 
   <div class="d-grid gap-3">
@@ -22,6 +22,6 @@
     <% end %>
   </div>
   <div class='d-flex justify-content-center mt-5 mb-3'>
-    <%= link_to "Back", orders_path, class: 'btn btn-primary' %>
+    <%= link_to "Back", dashboard_path, class: 'btn btn-primary' %>
   </div>
 </div>


### PR DESCRIPTION
- made the back btn in order status go to dashboard instead of orders index
- fixed the left padding to 0 in the Order Status title

@CloneProtocolSixtySix please check and merge